### PR TITLE
maxlim

### DIFF
--- a/bomber.py
+++ b/bomber.py
@@ -562,7 +562,7 @@ elif type == 0:
             input("Enter Delay time (in seconds) [Recommended 10 sec ] : "))
 maxlim = 0
 if cc == "91":
-    maxlim = 500
+    maxlim = 5000000
 else:
     maxlim = 100
 if nm > maxlim:


### PR DESCRIPTION
maxlim should have greater limit because the number of count you want to send the targeted person not goes ...
 for e.g if you have select 500 maxlim then msg is sended only  50. which is very less from desire amount of once