### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ bash TBomb.sh
 
 To use the application, type in the following commands in MacOS terminal:
 
-##### Install Brew
+##### Install via Homebrew
 
 ```shell script
-/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ````
 
 ##### Install dependencies:


### PR DESCRIPTION
```
#!/usr/bin/ruby

STDERR.print <<EOS
Warning: The Ruby Homebrew installer is now deprecated and has been rewritten in
Bash. Please migrate to the following command:
  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"

EOS

Kernel.exec "/bin/bash", "-c", '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
```